### PR TITLE
support Django>=4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 # pip install .
 dependencies = [
-    "django>=4.2.11",
+    "django>=4.0.0",
     "djangorestframework>=3.14.0",
     "drf-spectacular>=0.27.2",
     "drf-spectacular-sidecar>=2024.4.1",


### PR DESCRIPTION
The library pinned Django 4.2, but it works for Django 4.0 and 4.1 too.